### PR TITLE
Fix for 2 vulnerable dependency paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
 		"async": "~0.9.0",
 		"compressjs": "~1.0.2",
 		"gbxremote": "~0.1.4",
-		"request": "~2.51.0",
+		"request": "~2.74.0",
 		"minimist": "~1.1.0",
 		"varint": "~4.0.0",
 		"moment": "~2.9.0"


### PR DESCRIPTION
node-gamedig currently has a 2 vulnerable dependency, introducing 3 different types of known vulnerabilities.

This PR fixes two vulnerable dependency, introducing [remote memory exposure ](https://snyk.io/vuln/npm:request:20160119) vulnerability in the `request` dependency and [ReDos vulnerability](https://snyk.io/vuln/npm:hawk:20160119) in the `hawk` dependency. 

You can see [Snyk test report](https://snyk.io/test/github/sonicsnes/node-gamedig) of this project for details. 

This PR changes `Package.json` to upgrade `request` to the newer 2.74.0 version, and will fix  the vulnerability listed above.
You can get alerts and fix PRs for future vulnerabilities for free by [watching this repo with Snyk](https://snyk.io/add).

Note this PR fixes all the vulnerabilities introduced trough `request` dependency, in order to be vulnerability free you will need to upgrade ` moment` dependency as well.

Full disclosure: I'm a part of the Snyk team, just looking to spread some security goodness and awareness ;)